### PR TITLE
fix nushell integration

### DIFF
--- a/.github/workflows/dorothy-workflow.yml
+++ b/.github/workflows/dorothy-workflow.yml
@@ -19,7 +19,7 @@ jobs:
           # ensure dorothy is cloned, and run command
           bash -c "$(curl -fsSL 'https://dorothy.bevry.me/install?branch=${{ github.ref_name }}&commit=${{ github.sha }}')"
       - name: 'Dorothy Login Shell: nu'
-        shell: env RUST_BACKTRACE=1 nu -l -e {0}
+        shell: env RUST_BACKTRACE=1 nu -l --log-level trace -e {0}
         run: |
           command-exists dorothy
           echo-style --success='ok'

--- a/.github/workflows/dorothy-workflow.yml
+++ b/.github/workflows/dorothy-workflow.yml
@@ -8,168 +8,19 @@ concurrency:
 jobs:
   homebrew-macos-checks:
     runs-on: macos-latest
-    env:
-      CI_COMMIT_MESSAGE: 'ci: adjustments'
-      CI_COMMIT_NAME: 'Continuous Integration'
-      CI_COMMIT_EMAIL: 'bot@bevry.me'
     steps:
-      - name: 'Dorothy Install'
+      - name: 'Nu + Dorothy Install'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # prevent rate limiting
         shell: bash
         run: |
+          # install nu so is available to dorothy's install configuration
+          brew install nushell
           # ensure dorothy is cloned, and run command
           bash -c "$(curl -fsSL 'https://dorothy.bevry.me/install?branch=${{ github.ref_name }}&commit=${{ github.sha }}')"
-      - name: 'Dorothy Configure'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # prevent rate limiting
-        shell: bash -leo pipefail {0}
-        run: |
-          # prep linting
-          dorothy dev
-          # prep login shells
-          setup-util-bash
-          setup-util-zsh
-          setup-util-fish
-          setup-util-nu
-          dorothy install
-      - name: 'Dorothy Login Shell: bash'
-        shell: bash -leo pipefail {0}
-        run: |
-          command-exists dorothy
-          echo-style --success='ok'
-      - name: 'Dorothy Login Shell: zsh'
-        shell: zsh -l {0}
-        run: |
-          command-exists dorothy
-          echo-style --success='ok'
-      - name: 'Dorothy Login Shell: fish'
-        shell: fish -l {0}
-        run: |
-          command-exists dorothy
-          echo-style --success='ok'
       - name: 'Dorothy Login Shell: nu'
-        shell: nu -l -e {0}
+        shell: RUST_BACKTRACE=1 nu -l -e {0}
         run: |
           command-exists dorothy
           echo-style --success='ok'
           exit
-      - name: 'Trunk Format'
-        if: github.event_name == 'push'
-        shell: bash -leo pipefail {0}
-        run: |
-          dorothy format
-          # commit changes, if any
-          cd "$DOROTHY"
-          if git diff --quiet &>/dev/null; then
-            echo 'Already formatted.'
-          else
-            git config --global user.name "${{ env.CI_COMMIT_NAME }}"
-            git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
-            git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
-            git push
-          fi
-      - name: 'Trunk Check'
-        shell: bash -leo pipefail {0}
-        run: dorothy check
-  homebrew-macos-test:
-    runs-on: macos-latest
-    steps:
-      - name: 'Dorothy Test'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # prevent rate limiting
-        shell: bash
-        run: |
-          # ensure dorothy is cloned, and run command
-          bash -c "$(curl -fsSL 'https://dorothy.bevry.me/run?branch=${{ github.ref_name }}&commit=${{ github.sha }}')" -- dorothy test
-  fresh-macos-test:
-    runs-on: macos-latest
-    steps:
-      - name: 'Uninstall Homebrew'
-        shell: bash
-        run: |
-          # run homebrew uninstaller
-          bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh')"
-      - name: 'Dorothy Test'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # prevent rate limiting
-        shell: bash
-        run: |
-          # ensure dorothy is cloned, and run command
-          bash -c "$(curl -fsSL 'https://dorothy.bevry.me/run?branch=${{ github.ref_name }}&commit=${{ github.sha }}')" -- dorothy test
-  distro-test:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        container:
-          - 'ubuntu:latest' # https://hub.docker.com/_/ubuntu
-          - 'fedora:latest' # https://hub.docker.com/_/fedora
-          - 'debian:latest' # https://hub.docker.com/_/debian
-          - 'alpine:latest' # https://hub.docker.com/_/alpine <-- script -qec workaround for TTY does not work on alpine
-          - 'manjarolinux/base' # https://hub.docker.com/r/manjarolinux/base
-          - 'opensuse/leap' # https://hub.docker.com/r/opensuse/leap <-- has outdated bash, so is good to test
-          - 'opensuse/tumbleweed' # https://hub.docker.com/r/opensuse/tumbleweed
-          - 'kalilinux/kali-rolling' # https://hub.docker.com/r/kalilinux/kali-rolling <-- apt based
-          - 'voidlinux/voidlinux' # https://hub.docker.com/r/voidlinux/voidlinux <-- locale failure
-          # - 'mageia:cauldron' # https://hub.docker.com/_/mageia <-- cauldron is were moreutils is, disabled as couldn't get working
-          # - 'nixos/nix' # https://hub.docker.com/r/nixos/nix <-- doesn't make bash available to env, also locale failure
-          # - 'gentoo/stage3' # https://hub.docker.com/r/gentoo/stage3 <-- couldn't get to work due to home misconfigure error
-    container:
-      image: ${{ matrix.container }}
-    steps:
-      - name: 'Dorothy Dependencies'
-        # don't use [shell: bash] here yet for linux distros, as may not exist yet
-        run: |
-          # this should somewhat coincide with [commands/dorothy:ensure_prereq_dependencies]
-          if command -v apt-get; then
-            # for ubuntu/debian/kali
-            apt-get update
-            apt-get install -y bash curl git
-          elif command -v zypper; then
-            # for opensuse
-            zypper --non-interactive --gpg-auto-import-keys refresh
-            zypper --non-interactive install bash curl
-          elif command -v apk; then
-            # for alpine
-            apk update
-            apk add bash curl git grep
-          elif command -v pamac; then
-            # for manjaro, prefer over arch as majaro also contains pacman
-            pamac install --no-confirm bash curl
-          elif command -v pacman; then
-            # for arch
-            pacman-key --init
-            pacman --refresh --sync --needed --noconfirm bash curl
-          elif command -v urpmi; then
-            # for mageia, prefer over fedora as mageia also contains dnf
-            # https://wiki.mageia.org/en/Cauldron
-            # --allowerasing needed due to: https://github.com/bevry/dorothy/actions/runs/6033044029/job/16369147940
-            # urpmi --auto-update --auto
-            # dnf check-update --assumeyes
-            # dnf upgrade --assumeyes --refresh --best --allowerasing
-            # ^ disabled as always fails
-            urpmi.update -a
-            # ^ this fails too: https://github.com/bevry/dorothy/actions/runs/6033557632/job/16370418074
-            urpmi --auto bash curl
-          elif command -v dnf; then
-            # for fedora
-            dnf --assumeyes --refresh --best --allowerasing install bash curl
-          elif command -v xbps-install; then
-            # for void linux
-            xbps-install --sync --update --yes xbps
-            xbps-install --sync --yes bash curl
-          elif command -v nix-env; then
-            # for nix
-            nix-env --install --attr nixpkgs.bash nixpkgs.curl
-          elif command -v emerge; then
-            # for gentoo
-            emerge app-shells/bash net-misc/curl
-          fi
-      - name: 'Dorothy Remote Tests'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # prevent rate limiting
-        shell: bash
-        run: |
-          # ensure dorothy is cloned, and run command
-          bash -c "$(curl -fsSL 'https://dorothy.bevry.me/run?branch=${{ github.ref_name }}&commit=${{ github.sha }}')" -- dorothy test

--- a/.github/workflows/dorothy-workflow.yml
+++ b/.github/workflows/dorothy-workflow.yml
@@ -33,9 +33,6 @@ jobs:
           setup-util-fish
           setup-util-nu
           dorothy install
-          nuloginfile="$(nu -c 'echo $nu.loginshell-path')"
-          printf '%s\n' "echo 'LOADED >-- $nuloginfile <--'" >> "$nuloginfile"
-          echo-file "$nuloginfile"
       - name: 'Dorothy Login Shell: bash'
         shell: bash -leo pipefail {0}
         run: |
@@ -52,10 +49,11 @@ jobs:
           command-exists dorothy
           echo-style --success='ok'
       - name: 'Dorothy Login Shell: nu'
-        shell: nu -l {0}
+        shell: nu -l -e {0}
         run: |
           command-exists dorothy
           echo-style --success='ok'
+          exit
       - name: 'Trunk Format'
         if: github.event_name == 'push'
         shell: bash -leo pipefail {0}

--- a/.github/workflows/dorothy-workflow.yml
+++ b/.github/workflows/dorothy-workflow.yml
@@ -19,7 +19,7 @@ jobs:
           # ensure dorothy is cloned, and run command
           bash -c "$(curl -fsSL 'https://dorothy.bevry.me/install?branch=${{ github.ref_name }}&commit=${{ github.sha }}')"
       - name: 'Dorothy Login Shell: nu'
-        shell: RUST_BACKTRACE=1 nu -l -e {0}
+        shell: env RUST_BACKTRACE=1 nu -l -e {0}
         run: |
           command-exists dorothy
           echo-style --success='ok'

--- a/.github/workflows/dorothy-workflow.yml
+++ b/.github/workflows/dorothy-workflow.yml
@@ -2,19 +2,52 @@ name: dorothy-workflow
 'on':
   - push
   - pull_request
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   homebrew-macos-checks:
     runs-on: macos-latest
+    env:
+      CI_COMMIT_MESSAGE: 'ci: adjustments'
+      CI_COMMIT_NAME: 'Continuous Integration'
+      CI_COMMIT_EMAIL: 'bot@bevry.me'
     steps:
-      - name: 'Nu + Dorothy Install'
+      - name: 'Dorothy Install'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # prevent rate limiting
         shell: bash
         run: |
-          # install nu so is available to dorothy's install configuration
-          brew install nushell
           # ensure dorothy is cloned, and run command
           bash -c "$(curl -fsSL 'https://dorothy.bevry.me/install?branch=${{ github.ref_name }}&commit=${{ github.sha }}')"
+      - name: 'Dorothy Configure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # prevent rate limiting
+        shell: bash -leo pipefail {0}
+        run: |
+          # prep linting
+          dorothy dev
+          # prep login shells
+          setup-util-bash
+          setup-util-zsh
+          setup-util-fish
+          setup-util-nu
+          dorothy install
+      - name: 'Dorothy Login Shell: bash'
+        shell: bash -leo pipefail {0}
+        run: |
+          command-exists dorothy
+          echo-style --success='ok'
+      - name: 'Dorothy Login Shell: zsh'
+        shell: zsh -l {0}
+        run: |
+          command-exists dorothy
+          echo-style --success='ok'
+      - name: 'Dorothy Login Shell: fish'
+        shell: fish -l {0}
+        run: |
+          command-exists dorothy
+          echo-style --success='ok'
       - name: 'Dorothy Login Shell: nu'
         shell: nu -l {0}
         run: |
@@ -23,4 +56,122 @@ jobs:
           # continue as normal
           command-exists dorothy
           echo-style --success='ok'
-          exit
+      - name: 'Trunk Format'
+        if: github.event_name == 'push'
+        shell: bash -leo pipefail {0}
+        run: |
+          dorothy format
+          # commit changes, if any
+          cd "$DOROTHY"
+          if git diff --quiet &>/dev/null; then
+            echo 'Already formatted.'
+          else
+            git config --global user.name "${{ env.CI_COMMIT_NAME }}"
+            git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
+            git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
+            git push
+          fi
+      - name: 'Trunk Check'
+        shell: bash -leo pipefail {0}
+        run: dorothy check
+  homebrew-macos-test:
+    runs-on: macos-latest
+    steps:
+      - name: 'Dorothy Test'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # prevent rate limiting
+        shell: bash
+        run: |
+          # ensure dorothy is cloned, and run command
+          bash -c "$(curl -fsSL 'https://dorothy.bevry.me/run?branch=${{ github.ref_name }}&commit=${{ github.sha }}')" -- dorothy test
+  fresh-macos-test:
+    runs-on: macos-latest
+    steps:
+      - name: 'Uninstall Homebrew'
+        shell: bash
+        run: |
+          # run homebrew uninstaller
+          bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh')"
+      - name: 'Dorothy Test'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # prevent rate limiting
+        shell: bash
+        run: |
+          # ensure dorothy is cloned, and run command
+          bash -c "$(curl -fsSL 'https://dorothy.bevry.me/run?branch=${{ github.ref_name }}&commit=${{ github.sha }}')" -- dorothy test
+  distro-test:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container:
+          - 'ubuntu:latest' # https://hub.docker.com/_/ubuntu
+          - 'fedora:latest' # https://hub.docker.com/_/fedora
+          - 'debian:latest' # https://hub.docker.com/_/debian
+          - 'alpine:latest' # https://hub.docker.com/_/alpine <-- script -qec workaround for TTY does not work on alpine
+          - 'manjarolinux/base' # https://hub.docker.com/r/manjarolinux/base
+          - 'opensuse/leap' # https://hub.docker.com/r/opensuse/leap <-- has outdated bash, so is good to test
+          - 'opensuse/tumbleweed' # https://hub.docker.com/r/opensuse/tumbleweed
+          - 'kalilinux/kali-rolling' # https://hub.docker.com/r/kalilinux/kali-rolling <-- apt based
+          - 'voidlinux/voidlinux' # https://hub.docker.com/r/voidlinux/voidlinux <-- locale failure
+          # - 'mageia:cauldron' # https://hub.docker.com/_/mageia <-- cauldron is were moreutils is, disabled as couldn't get working
+          # - 'nixos/nix' # https://hub.docker.com/r/nixos/nix <-- doesn't make bash available to env, also locale failure
+          # - 'gentoo/stage3' # https://hub.docker.com/r/gentoo/stage3 <-- couldn't get to work due to home misconfigure error
+    container:
+      image: ${{ matrix.container }}
+    steps:
+      - name: 'Dorothy Dependencies'
+        # don't use [shell: bash] here yet for linux distros, as may not exist yet
+        run: |
+          # this should somewhat coincide with [commands/dorothy:ensure_prereq_dependencies]
+          if command -v apt-get; then
+            # for ubuntu/debian/kali
+            apt-get update
+            apt-get install -y bash curl git
+          elif command -v zypper; then
+            # for opensuse
+            zypper --non-interactive --gpg-auto-import-keys refresh
+            zypper --non-interactive install bash curl
+          elif command -v apk; then
+            # for alpine
+            apk update
+            apk add bash curl git grep
+          elif command -v pamac; then
+            # for manjaro, prefer over arch as majaro also contains pacman
+            pamac install --no-confirm bash curl
+          elif command -v pacman; then
+            # for arch
+            pacman-key --init
+            pacman --refresh --sync --needed --noconfirm bash curl
+          elif command -v urpmi; then
+            # for mageia, prefer over fedora as mageia also contains dnf
+            # https://wiki.mageia.org/en/Cauldron
+            # --allowerasing needed due to: https://github.com/bevry/dorothy/actions/runs/6033044029/job/16369147940
+            # urpmi --auto-update --auto
+            # dnf check-update --assumeyes
+            # dnf upgrade --assumeyes --refresh --best --allowerasing
+            # ^ disabled as always fails
+            urpmi.update -a
+            # ^ this fails too: https://github.com/bevry/dorothy/actions/runs/6033557632/job/16370418074
+            urpmi --auto bash curl
+          elif command -v dnf; then
+            # for fedora
+            dnf --assumeyes --refresh --best --allowerasing install bash curl
+          elif command -v xbps-install; then
+            # for void linux
+            xbps-install --sync --update --yes xbps
+            xbps-install --sync --yes bash curl
+          elif command -v nix-env; then
+            # for nix
+            nix-env --install --attr nixpkgs.bash nixpkgs.curl
+          elif command -v emerge; then
+            # for gentoo
+            emerge app-shells/bash net-misc/curl
+          fi
+      - name: 'Dorothy Remote Tests'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # prevent rate limiting
+        shell: bash
+        run: |
+          # ensure dorothy is cloned, and run command
+          bash -c "$(curl -fsSL 'https://dorothy.bevry.me/run?branch=${{ github.ref_name }}&commit=${{ github.sha }}')" -- dorothy test

--- a/.github/workflows/dorothy-workflow.yml
+++ b/.github/workflows/dorothy-workflow.yml
@@ -2,9 +2,6 @@ name: dorothy-workflow
 'on':
   - push
   - pull_request
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   homebrew-macos-checks:
     runs-on: macos-latest
@@ -19,7 +16,7 @@ jobs:
           # ensure dorothy is cloned, and run command
           bash -c "$(curl -fsSL 'https://dorothy.bevry.me/install?branch=${{ github.ref_name }}&commit=${{ github.sha }}')"
       - name: 'Dorothy Login Shell: nu'
-        shell: env RUST_BACKTRACE=1 nu -l --log-level trace -e {0}
+        shell: nu -l -e {0}
         run: |
           command-exists dorothy
           echo-style --success='ok'

--- a/.github/workflows/dorothy-workflow.yml
+++ b/.github/workflows/dorothy-workflow.yml
@@ -33,7 +33,9 @@ jobs:
           setup-util-fish
           setup-util-nu
           dorothy install
-          echo-file "$(nu -c 'echo $nu.loginshell-path')"
+          nuloginfile="$(nu -c 'echo $nu.loginshell-path')"
+          printf '%s\n' "echo 'LOADED >-- $nuloginfile <--'" >> "$nuloginfile"
+          echo-file "$nuloginfile"
       - name: 'Dorothy Login Shell: bash'
         shell: bash -leo pipefail {0}
         run: |

--- a/.github/workflows/dorothy-workflow.yml
+++ b/.github/workflows/dorothy-workflow.yml
@@ -16,8 +16,11 @@ jobs:
           # ensure dorothy is cloned, and run command
           bash -c "$(curl -fsSL 'https://dorothy.bevry.me/install?branch=${{ github.ref_name }}&commit=${{ github.sha }}')"
       - name: 'Dorothy Login Shell: nu'
-        shell: nu -l -e {0}
+        shell: nu -l {0}
         run: |
+          # source ... is a workaround for: https://discord.com/channels/601130461678272522/1147584426121896067
+          source '/Users/runner/Library/Application Support/nushell/login.nu'
+          # continue as normal
           command-exists dorothy
           echo-style --success='ok'
           exit

--- a/commands/setup-util-nu
+++ b/commands/setup-util-nu
@@ -51,16 +51,16 @@ function setup_util_nu() (
 			cat <<-EOF >"$DOROTHY/user/config.local/interactive.nu"
 				#!/usr/bin/env nu
 
-				# load the dorothy defaults
-				source ~/.local/share/dorothy/config/interactive.nu
+				# load my public configuration
+				source ../config/interactive.nu
 			EOF
 		fi
 		if test ! -f "$DOROTHY/user/config/interactive.nu"; then
 			cat <<-EOF >"$DOROTHY/user/config/interactive.nu"
 				#!/usr/bin/env nu
 
-				# load my public configuration
-				source ../config/interactive.nu
+				# load the dorothy defaults
+				source ~/.local/share/dorothy/config/interactive.nu
 			EOF
 		fi
 	}

--- a/commands/setup-util-nu
+++ b/commands/setup-util-nu
@@ -27,24 +27,9 @@ function setup_util_nu() (
 		# trunk-ignore(shellcheck/SC2016)
 		mkdir -p "$(nu -c 'echo $nu.default-config-dir')"
 
-		# ensure [themes/starship.nu] works
-		if test ! -f "$XDG_STATE_HOME/starship/init.nu"; then
-			mkdir -p "$XDG_STATE_HOME/starship"
-			if command-exists starship; then
-				starship init nu >"$XDG_STATE_HOME/starship/init.nu"
-			else
-				# when the user wants starship theme, install it then and prompt for reload
-				cat <<-EOF >"$XDG_STATE_HOME/starship/init.nu"
-					#!/usr/bin/env nu
-
-					echo-style --notice='Starship not yet installed, installing...'
-					setup-util-starship
-					echo-style --notice='Configuring Nu for Starship...'
-					setup-util-nu
-					echo-style --notice='Reload your terminal...'
-				EOF
-			fi
-		fi
+		# ensure [themes/starship.nu] works for [themes/starship.nu] to set it up later
+		mkdir -p "$XDG_STATE_HOME/starship"
+		touch "$XDG_STATE_HOME/starship/init.nu"
 
 		# ensure [sources/interactive.nu] works
 		if test ! -f "$DOROTHY/user/config.local/interactive.nu"; then

--- a/themes/starship.nu
+++ b/themes/starship.nu
@@ -1,16 +1,23 @@
 #!/usr/bin/env nu
 
 # ensure starship
+mut reload_required_for_starship = false
 command-exists 'starship' | complete
-if $env.LAST_EXIT_CODE == 0 {
+if $env.LAST_EXIT_CODE != 0 {
+	# starship is missing, install it
 	setup-util-starship --quiet
+	$reload_required_for_starship = true
+}
+if ( open ~/.local/state/starship/init.nu | length ) == 0 {
+	# init script is placeholder, update it
+	starship init nu | save --force ~/.local/state/starship/init.nu
+	$reload_required_for_starship = true
+}
+if $reload_required_for_starship == true {
+	# reload the shell to ensure starship is loaded
+	echo-style --notice='Starship installed, reload your terminal.'
+	exit 35 # EAGAIN 35 Resource temporarily unavailable
 }
 
-# ensure starship nushell <-- no point, as nushell requires everything to already be as intended at compile-time
-# if ( ~/.local/state/starship/init.nu | path exists ) == false {
-# 	mkdir ~/.local/state/starship
-# 	starship init nu | save ~/.local/state/starship/init.nu
-# fi
-
-# load starship nushell
+# load the actual starship init script
 use ~/.local/state/starship/init.nu


### PR DESCRIPTION
Nushell integration has been broken since its introduction — 61662e8b5b920038d8c2d88e9e35ea79766099dd — as the configuration files that Dorothy would created would cause an infinite loop as of them loads itself instead of another file... the reason it continued to work for me, is I already had the correct configuration files, so I was not affected by the bad creation of them. This was fixed in: 1a735c7469ac0a306ac2edbc8c45879013cb5718

Another issue was the Starship theme handling. It was far more complicated and unreliable than it needed to be. Now the appropriate place for it handles it correctly: ab2d6adbfd034d93a2db804603b27899f93dcfcd

Finally, Nushell does not load the `login.nu` configuration file with `-l` and `-l -c`. It does however load it with `-l -e` however that requires a TTY which GitHub Actions does not have, so it crashes. I have reported it here: https://discord.com/channels/601130461678272522/1147584426121896067 and it is fixed here: b653506c177d786291822137e55a8964f0ad7092