### PR TITLE
dorothy: fix uninstall action not being callable due to missing map

### DIFF
--- a/commands/dorothy
+++ b/commands/dorothy
@@ -392,6 +392,9 @@ function dorothy() (
 		't' | 'test')
 			action='test'
 			;;
+		'u' | 'uninstall')
+			action='uninstall'
+			;;
 		'todo' | 'todos')
 			action='todos'
 			;;


### PR DESCRIPTION
Add in missing action uninstall as decribed in help.

Action once added successfully uninstalls dorothy.