### PR TITLE
Fix problem caused by a non-standard installation of yarn.

### DIFF
--- a/commands/setup-environment-commands
+++ b/commands/setup-environment-commands
@@ -592,7 +592,7 @@ if test -d "$HOME/.clojure/clojure-1.8"; then
 fi
 
 # Yarn
-if command-exists yarn; then
+if command-exists yarn && yarn global bin &>/dev/null; then
 	# on CI, yarn exists, yet this can return nothing
 	p="$(yarn global bin 2>/dev/null)"
 	if test -n "$p"; then


### PR DESCRIPTION
I use [volta](https://volta.sh/) to install JavaScript-related tools (and yarn was installed this way on my local machine). This caused problems with the assumption dorothy does about the way yarn is installed.