### PR TITLE
ci: add debug-env job, run PRs on non-draft, open, and assigned

### DIFF
--- a/.github/workflows/dorothy-workflow.yml
+++ b/.github/workflows/dorothy-workflow.yml
@@ -8,8 +8,31 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  debug-env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Debug Environment'
+        shell: bash -leo pipefail {0}
+        run: |
+          # output github context
+          cat <<-EGITHUB
+            run?
+            ${{ toJson( github.event_name == 'push' || ( github.event_name == 'pull_request' && toJson(github.event.pull_request.draft) == 'false' && toJson(github.event.pull_request.state) == '"open"' && toJson(github.event.pull_request.assignees) != '[]' ) ) }}
+
+            github.event_name:
+            ${{ toJson(github.event_name) }}
+
+            github.event.pull_request.draft:
+            ${{ github.event_name == 'pull_request' && toJson(github.event.pull_request.draft) }}
+
+            github.event.pull_request.state:
+            ${{ github.event_name == 'pull_request' && toJson(github.event.pull_request.state) }}
+
+            github.event.pull_request.assignees:
+            ${{ github.event_name == 'pull_request' && toJson( toJson(github.event.pull_request.assignees) != '[]' ) }}
+          EGITHUB
   login-shells-and-linting:
-    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && (toJSON(github.event.pull_request.requested_reviewers) != '[]' || toJSON(github.event.pull_request.requested_teams) != '[]' ) )
+    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && toJson(github.event.pull_request.draft) == 'false' && toJson(github.event.pull_request.state) == '"open"' && toJson(github.event.pull_request.assignees) != '[]' )
     runs-on: ubuntu-latest
     steps:
       - name: 'Dorothy Install'
@@ -112,7 +135,7 @@ jobs:
         run: dorothy check
   # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
   runner-test:
-    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && (toJSON(github.event.pull_request.requested_reviewers) != '[]' || toJSON(github.event.pull_request.requested_teams) != '[]' ) )
+    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && toJson(github.event.pull_request.draft) == 'false' && toJson(github.event.pull_request.state) == '"open"' && toJson(github.event.pull_request.assignees) != '[]' )
     strategy:
       fail-fast: false
       matrix:
@@ -127,7 +150,7 @@ jobs:
           # ensure dorothy is cloned, and run command
           bash -c "$(curl -fsSL 'https://dorothy.bevry.me/run?slug=${{ github.repository }}&commit=${{ github.event.pull_request.head.sha || github.sha }}')" -- dorothy test
   fresh-macos-test:
-    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && (toJSON(github.event.pull_request.requested_reviewers) != '[]' || toJSON(github.event.pull_request.requested_teams) != '[]' ) )
+    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && toJson(github.event.pull_request.draft) == 'false' && toJson(github.event.pull_request.state) == '"open"' && toJson(github.event.pull_request.assignees) != '[]' )
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +168,7 @@ jobs:
           # ensure dorothy is cloned, and run command
           bash -c "$(curl -fsSL 'https://dorothy.bevry.me/run?slug=${{ github.repository }}&commit=${{ github.event.pull_request.head.sha || github.sha }}')" -- dorothy test
   container-test:
-    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && (toJSON(github.event.pull_request.requested_reviewers) != '[]' || toJSON(github.event.pull_request.requested_teams) != '[]' ) )
+    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && toJson(github.event.pull_request.draft) == 'false' && toJson(github.event.pull_request.state) == '"open"' && toJson(github.event.pull_request.assignees) != '[]' )
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
don't output uncontrolled variables, as they could do something like `$(...)`

- /ref https://github.com/bevry/dorothy/actions/runs/11544835660
- /ref https://github.com/bevry/dorothy/actions/runs/11545070866/job/32131472674
- /ref https://github.com/bevry/dorothy/actions/runs/11545090502/job/32131521957
- /ref https://github.com/bevry/dorothy/actions/runs/11545101737/job/32131558100?pr=259
- /ref https://github.com/bevry/dorothy/actions/runs/11545157873/job/32131693784?pr=259
- /ref https://github.com/bevry/dorothy/actions/runs/11545169658/job/32131723989
- /ref https://github.com/bevry/dorothy/actions/runs/11545238570/job/32131907444?pr=259
- /ref https://github.com/bevry/dorothy/actions/runs/11545298089/job/32132041989?pr=259
- /ref https://github.com/bevry/dorothy/actions/runs/11545327141/job/32132117245?pr=259
