### PR TITLE
init: properly enable `NVIM` support

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -62,6 +62,7 @@ else
 	DOROTHY_LOAD='no' # this must be outside the below if, to ensure DOROTHY_LOAD is reset, and DOROTHY_LOADED is respected, otherwise posix shells may double load due to cross-compat between dotfiles (.profile along with whatever they support)
 	if [ -z "${DOROTHY_LOADED_SHARED_SCOPE-}" ]; then
 		# `-dash` is macos login shell, `dash` is manual `dash -l` invocation (as $- doesn't include l in dash)
+		# NVIM here because it sets $0 as whichever shell invoked Neovim: https://github.com/bevry/dorothy/pull/279$0
 		if [ "$0" = '-bash' ] || [ "$0" = '-zsh' ] || [ "$0" = '-dash' ] || [ "$0" = 'dash' ] || [ -n "${NVIM-}" ]; then
 			DOROTHY_LOAD='yes'
 		elif [ -n "${BASH_VERSION-}" ]; then

--- a/init.sh
+++ b/init.sh
@@ -62,7 +62,7 @@ else
 	DOROTHY_LOAD='no' # this must be outside the below if, to ensure DOROTHY_LOAD is reset, and DOROTHY_LOADED is respected, otherwise posix shells may double load due to cross-compat between dotfiles (.profile along with whatever they support)
 	if [ -z "${DOROTHY_LOADED_SHARED_SCOPE-}" ]; then
 		# `-dash` is macos login shell, `dash` is manual `dash -l` invocation (as $- doesn't include l in dash)
-		if [ "$0" = '-bash' ] || [ "$0" = '-zsh' ] || [ "$0" = '-dash' ] || [ "$0" = 'dash' ]; then
+		if [ "$0" = '-bash' ] || [ "$0" = '-zsh' ] || [ "$0" = '-dash' ] || [ "$0" = 'dash' ] || [ -n "${NVIM-}" ]; then
 			DOROTHY_LOAD='yes'
 		elif [ -n "${BASH_VERSION-}" ]; then
 			# trunk-ignore(shellcheck/SC3044)
@@ -78,8 +78,6 @@ else
 			fi
 		elif [ -z "$-" ] && [ -z "$*" ] && [ "${CI-}" = 'true' ]; then
 			DOROTHY_LOAD='yes' # dash on github ci, in which [$-] and [$*] are empty, and $0 = /home/runner....
-		elif [ -n "${NVIM-}" ]; then
-			DOROTHY_LOAD='yes' # neovim: $0 = init.sh, and BASH_SOURCE[*] is undefined
 		else
 			# bash v3 and dash do not set l in $-
 			# zsh does, however zsh we have a definite option earlier


### PR DESCRIPTION
Under neovim, `$0` is the shell that invoked neovim, so if zsh is used to invoke neovim then it would be `zsh`. This is because of `/bin/zsh -c 'echo $0'` is `/bin/zsh` and `zsh -c 'echo $0'` is `zsh`. As such, we need to do the NVIM check earlier, as otherwise it will fall into the other checks, as `BASH_VERSION` will exit is bash invoked and `ZSH_VERSION` will exist if zsh invoked.


---
Original:

Neovim terminal returns `$0` differently from standard shell and so it has to be handled at the first conditional check.
Otherwise, dorothy will enter other elif branches without actually loading in neovim.