### PR TITLE
ci: trunk: add comments that describe linters

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -21,23 +21,23 @@ actions:
     - trunk-upgrade-available
 lint:
   enabled:
-    - cspell@8.19.4
-    - bandit@1.8.3
-    - actionlint@1.7.7
-    - black@25.1.0
-    - checkov@3.2.416
-    - flake8@7.2.0
-    - git-diff-check@SYSTEM
-    - gitleaks@8.25.1
-    - isort@6.0.1
-    - markdownlint@0.44.0
-    - prettier@3.5.3
-    - ruff@0.11.8
-    - shellcheck@0.10.0
-    - shfmt@3.7.0
-    - taplo@0.9.3
-    - trufflehog@3.88.28
-    - yamllint@1.37.1
+    - cspell@8.19.4          # Spell checker for code, comments, and docs
+    - bandit@1.8.3           # Security linter for Python (finds common vulns)
+    - actionlint@1.7.7       # Validates GitHub Actions workflow syntax/logic
+    - black@25.1.0           # Opinionated Python code formatter
+    - checkov@3.2.416        # IaC security scanner (Terraform, CloudFormation, K8s, etc.)
+    - flake8@7.2.0           # Python style/lint checks (PEP8, bugs, complexity)
+    - git-diff-check@SYSTEM  # Lightweight checks on changed diffs (e.g., conflict markers/forbidden patterns)
+    - gitleaks@8.25.1        # Secret scanner for commits and repos
+    - isort@6.0.1            # Sorts & groups Python imports
+    - markdownlint@0.44.0    # Lints Markdown style and formatting
+    - prettier@3.5.3         # Formatter for JS/TS/JSON/CSS/Markdown/etc.
+    - ruff@0.11.8            # Fast Python linter (rules from Flake8/pylint), optional formatter
+    - shellcheck@0.10.0      # Static analysis for shell scripts (bash/sh)
+    - shfmt@3.7.0            # Shell script formatter
+    - taplo@0.9.3            # TOML linter/formatter (e.g., pyproject.toml)
+    - trufflehog@3.88.28     # High-signal secret detector (entropy + pattern matches)
+    - yamllint@1.37.1        # YAML syntax and style checker
   disabled:
     - eslint # it can't find the bevry config extensions for some reason
     - trivy


### PR DESCRIPTION
Update trunk.yaml to include a comment alongside each linter for what it actually does

> [!NOTE]
> This likely wont survive updates, but as a proof of concept, and hopefully to get you rolling here is a quick pass! 