### PR TITLE
fix(interactive): only print shoutout when stdout is a terminal

### DIFF
--- a/sources/interactive.sh
+++ b/sources/interactive.sh
@@ -15,8 +15,8 @@ if [ "$ACTIVE_POSIX_SHELL" = 'bash' ]; then
 	export HISTTIMEFORMAT='%F %T '
 fi
 
-# Shoutouts
-if command -v shuf >/dev/null 2>&1; then
+# Shoutouts — only when stdout is an actual terminal (not git hooks, pipes, TERM=dumb)
+if command -v shuf >/dev/null 2>&1 && [ -t 1 ] && [ "${TERM:-dumb}" != 'dumb' ]; then
 	shuf -n1 "$DOROTHY/sources/shoutouts.txt"
 fi
 dorothy-warnings warn

--- a/sources/interactive.sh
+++ b/sources/interactive.sh
@@ -15,11 +15,15 @@ if [ "$ACTIVE_POSIX_SHELL" = 'bash' ]; then
 	export HISTTIMEFORMAT='%F %T '
 fi
 
-# Shoutouts — only when stdout is an actual terminal (not git hooks, pipes, TERM=dumb)
-if command -v shuf >/dev/null 2>&1 && [ -t 1 ] && [ "${TERM:-dumb}" != 'dumb' ]; then
-	shuf -n1 "$DOROTHY/sources/shoutouts.txt"
+# Informs, only when stdout is an actual terminal (not git hooks, pipes, TERM=dumb)
+if [ -t 1 ] && [ "${TERM:-dumb}" != 'dumb' ]; then
+	# Shoutouts
+	if command -v shuf >/dev/null 2>&1; then
+		shuf -n1 "$DOROTHY/sources/shoutouts.txt"
+	fi
+	# Warnings
+	dorothy-warnings warn
 fi
-dorothy-warnings warn
 
 # =====================================
 # Configuration


### PR DESCRIPTION
The shoutout line ran on every interactive shell load, including non-terminal contexts such as git hooks, piped commands, and TERM=dumb sessions, where it polluted output. Guard it with `[ -t 1 ]` and a TERM check so it only prints to a real terminal.